### PR TITLE
AMQ-8317 add config param to toggle inclusive nomenclature in logging

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/AbstractLocker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/AbstractLocker.java
@@ -28,6 +28,7 @@ public abstract class AbstractLocker extends ServiceSupport implements Locker {
     protected boolean failIfLocked = false;
     protected long lockAcquireSleepInterval = DEFAULT_LOCK_ACQUIRE_SLEEP_INTERVAL;
     protected LockableServiceSupport lockable;
+    private boolean useNonInclusiveTerminologyInLogs = false; // will remove in AMQ-7514
 
     @Override
     public boolean keepAlive() throws IOException {
@@ -58,4 +59,17 @@ public abstract class AbstractLocker extends ServiceSupport implements Locker {
         this.lockable = lockableServiceSupport;
     }
 
+    public boolean isUseNonInclusiveTerminologyInLogs() {
+        return useNonInclusiveTerminologyInLogs;
+    }
+
+    /**
+     * Sets whether or not to use non-inclusive terminology in logs to maintain backwards
+     * compatibility with previous releases.
+     * @deprecated will be removed in a future release
+     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
+     */
+    public void setUseNonInclusiveTerminologyInLogs(final boolean useNonInclusiveTerminologyInLogs) {
+        this.useNonInclusiveTerminologyInLogs = useNonInclusiveTerminologyInLogs;
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -141,6 +141,8 @@ public class BrokerService implements Service {
     @SuppressWarnings("unused")
     private static final long serialVersionUID = 7353129142305630237L;
 
+    private boolean useNonInclusiveTerminologyInLogs = false; // will remove in AMQ-7514
+
     private boolean useJmx = true;
     private boolean enableStatistics = true;
     private boolean persistent = true;
@@ -483,14 +485,26 @@ public class BrokerService implements Service {
 
     public void masterFailed() {
         if (shutdownOnActiveFailure) {
-            LOG.error("The Master has failed ... shutting down");
+            if (useNonInclusiveTerminologyInLogs) {
+                LOG.error("The Master has failed ... shutting down");
+            } else {
+                LOG.error("The Active has failed ... shutting down");
+            }
             try {
                 stop();
             } catch (Exception e) {
-                LOG.error("Failed to stop for master failure", e);
+                if (useNonInclusiveTerminologyInLogs) {
+                    LOG.error("Failed to stop for master failure", e);
+                } else {
+                    LOG.error("Failed to stop for Active failure", e);
+                }
             }
         } else {
-            LOG.warn("Master Failed - starting all connectors");
+            if (useNonInclusiveTerminologyInLogs) {
+                LOG.warn("Master Failed - starting all connectors");
+            } else {
+                LOG.warn("Active Failed - starting all connectors");
+            }
             try {
                 startAllConnectors();
                 broker.nowMasterBroker();
@@ -1128,6 +1142,20 @@ public class BrokerService implements Service {
      */
     public void setPersistent(boolean persistent) {
         this.persistent = persistent;
+    }
+
+    public boolean isUseNonInclusiveTerminologyInLogs() {
+        return useNonInclusiveTerminologyInLogs;
+    }
+
+    /**
+     * Sets whether or not to use non-inclusive terminology in logs to maintain backwards
+     * compatibility with previous releases.
+     * @deprecated will be removed in a future release
+     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
+     */
+    public void setUseNonInclusiveTerminologyInLogs(boolean useNonInclusiveTerminologyInLogs) {
+        this.useNonInclusiveTerminologyInLogs = useNonInclusiveTerminologyInLogs;
     }
 
     public boolean isPopulateJMSXUserID() {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
@@ -576,7 +576,11 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
     @Override
     public void nowMasterBroker() {
         if (isLogAll() || isLogInternalEvents()) {
-            LOG.info("Is now the master broker: {}", getBrokerName());
+            if (getBrokerService().isUseNonInclusiveTerminologyInLogs()) {
+                LOG.info("Is now the master broker: {}", getBrokerName());
+            } else {
+                LOG.info("Is now the Active broker: {}", getBrokerName());
+            }
         }
         super.nowMasterBroker();
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/SharedFileLocker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/SharedFileLocker.java
@@ -65,11 +65,18 @@ public class SharedFileLocker extends AbstractLocker {
                         locked = keepAlive();
                         break;
                     } catch (IOException e) {
-                        if (!warned)
-                        {
-                            LOG.info("Database "
-                                         + lockFileName
-                                         + " is locked by another server. This broker is now in slave mode waiting a lock to be acquired");
+                        if (!warned) {
+                            if (isUseNonInclusiveTerminologyInLogs()) {
+                                LOG.info("Database "
+                                    + lockFileName
+                                    + " is locked by another server."
+                                    + " This broker is now in slave mode waiting a lock to be acquired");
+                            } else {
+                                LOG.info("Database "
+                                    + lockFileName
+                                    + " is locked by another server."
+                                    + " This broker is now in Active mode waiting a lock to be acquired");
+                            }
                             warned = true;
                         }
 

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/DefaultDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/DefaultDatabaseLocker.java
@@ -43,7 +43,11 @@ public class DefaultDatabaseLocker extends AbstractJDBCLocker {
 
     public void doStart() throws Exception {
 
-        LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        } else {
+            LOG.info("Attempting to acquire the exclusive lock to become the Active broker");
+        }
         String sql = getStatements().getLockCreateStatement();
         LOG.debug("Locking Query is "+sql);
         
@@ -111,11 +115,19 @@ public class DefaultDatabaseLocker extends AbstractJDBCLocker {
             try {
                 Thread.sleep(lockAcquireSleepInterval);
             } catch (InterruptedException ie) {
-                LOG.warn("Master lock retry sleep interrupted", ie);
+                if (isUseNonInclusiveTerminologyInLogs()) {
+                    LOG.warn("Master lock retry sleep interrupted", ie);
+                } else {
+                    LOG.warn("Active lock retry sleep interrupted", ie);
+                }
             }
         }
 
-        LOG.info("Becoming the master on dataSource: " + dataSource);
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info("Becoming the master on dataSource: " + dataSource);
+        } else {
+            LOG.info("Becoming the Active on dataSource: " + dataSource);
+        }
     }
 
     public void doStop(ServiceStopper stopper) throws Exception {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/LeaseDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/LeaseDatabaseLocker.java
@@ -52,7 +52,11 @@ public class LeaseDatabaseLocker extends AbstractJDBCLocker {
                     + ", the lease duration. These values will allow the lease to expire.");
         }
 
-        LOG.info(getLeaseHolderId() + " attempting to acquire exclusive lease to become the master");
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info(getLeaseHolderId() + " attempting to acquire exclusive lease to become the master");
+        } else {
+            LOG.info(getLeaseHolderId() + " attempting to acquire exclusive lease to become the Active");
+        }
         String sql = getStatements().getLeaseObtainStatement();
         LOG.debug(getLeaseHolderId() + " locking Query is "+sql);
 
@@ -105,7 +109,15 @@ public class LeaseDatabaseLocker extends AbstractJDBCLocker {
             throw new RuntimeException(getLeaseHolderId() + " failing lease acquire due to stop");
         }
 
-        LOG.info(getLeaseHolderId() + ", becoming master with lease expiry " + new Date(now + lockAcquireSleepInterval) + " on dataSource: " + dataSource);
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info(getLeaseHolderId() + ", becoming master with lease expiry " + new Date(now + lockAcquireSleepInterval) + " on dataSource: " +
+                dataSource);
+        } else {
+            LOG.info("{}, becoming master with lease expiry {} on dataSource: {}",
+                getLeaseHolderId(),
+                new Date(now + lockAcquireSleepInterval),
+                dataSource);
+        }
     }
 
     private void reportLeasOwnerShipAndDuration(Connection connection) throws SQLException {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/TransactDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/TransactDatabaseLocker.java
@@ -16,15 +16,12 @@
  */
 package org.apache.activemq.store.jdbc.adapter;
 
-import java.io.IOException;
+import org.apache.activemq.store.jdbc.DefaultDatabaseLocker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
-import org.apache.activemq.store.jdbc.DefaultDatabaseLocker;
-import org.apache.activemq.store.jdbc.JDBCPersistenceAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents an exclusive lock on a database to avoid multiple brokers running
@@ -39,7 +36,11 @@ public class TransactDatabaseLocker extends DefaultDatabaseLocker {
     @Override
     public void doStart() throws Exception {
 
-        LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        } else {
+            LOG.info("Attempting to acquire the exclusive lock to become the Active broker");
+        }
         PreparedStatement statement = null;
         while (true) {
             try {
@@ -87,11 +88,19 @@ public class TransactDatabaseLocker extends DefaultDatabaseLocker {
             try {
             	Thread.sleep(lockAcquireSleepInterval);
             } catch (InterruptedException ie) {
-            	LOG.warn("Master lock retry sleep interrupted", ie);
+                if (isUseNonInclusiveTerminologyInLogs()) {
+                    LOG.warn("Master lock retry sleep interrupted", ie);
+                } else {
+                    LOG.warn("Active lock retry sleep interrupted", ie);
+                }
             }
         }
 
-        LOG.info("Becoming the master on dataSource: " + dataSource);
+        if (isUseNonInclusiveTerminologyInLogs()) {
+            LOG.info("Becoming the master on dataSource: " + dataSource);
+        } else {
+            LOG.info("Becoming the Active on dataSource: {}", dataSource);
+        }
     }
 
 }


### PR DESCRIPTION
This commit adds the parameter 'useNonInclusiveTerminologyInLogs'
as an opt-in backwards-compatible option for those that
rely on the legacy, non-inclusive terminolgy logged by
the Broker and the lease locker.